### PR TITLE
Fix issue #4

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "nodemon": "*",
     "apollo-client": "^0.8.1",
     "axios": "^0.15.3",
     "babel-core": "^6.22.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mongoose": "^4.7.8",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
-    "react": "^15.4.2",
+    "react": "15.4.2",
     "react-apollo": "^0.9.0",
     "react-dom": "^15.4.2",
     "react-router": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "passport-local": "^1.0.0",
     "react": "15.4.2",
     "react-apollo": "^0.9.0",
-    "react-dom": "^15.4.2",
+    "react-dom": "15.4.2",
     "react-router": "^3.0.2",
     "style-loader": "^0.13.1",
     "webpack": "^2.2.0",

--- a/server/schema/mutations.js
+++ b/server/schema/mutations.js
@@ -39,7 +39,7 @@ const mutation = new GraphQLObjectType({
       type: SongType,
       args: { id: { type: GraphQLID } },
       resolve(parentValue, { id }) {
-        return Song.findOneAndRemove(id);
+        return Song.remove({ _id: id });
       }
     }
   }

--- a/server/server.js
+++ b/server/server.js
@@ -14,7 +14,7 @@ if (!MONGO_URI) {
 }
 
 mongoose.Promise = global.Promise;
-mongoose.connect(MONGO_URI);
+mongoose.connect(MONGO_URI, {useMongoClient: true});
 mongoose.connection
     .once('open', () => console.log('Connected to MongoLab instance.'))
     .on('error', error => console.log('Error connecting to MongoLab:', error));


### PR DESCRIPTION
DeprecationWarning: `open()` is deprecated in mongoose >= 4.11.0, use `openUri()` instead, or set the `useMongoClient` option if using `connect()` or `createConnection()`
Db.prototype.authenticate method will no longer be available in the next major release 3.x as MongoDB 3.6 will only allow auth against users in the admin db and will no longer allow multiple credentials on a socket. Please authenticate using MongoClient.connect with auth credentials.


Using 'useMongoClient'