### PR TITLE
Add missing DOCTYPE and html tag

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,7 +1,10 @@
-<head>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.0/css/materialize.min.css">
-  <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-</head>
-<body>
-  <div id="root" />
-</body>
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.0/css/materialize.min.css">
+    <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  </head>
+  <body>
+    <div id="root" />
+  </body>
+</html>


### PR DESCRIPTION
The head and body should be enclosed in an `<html>` tag and there should be a `DOCTYPE` before it.