### PR TITLE
Fixed  "$pushAll" issue

### DIFF
--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,2 +1,6 @@
+const mongoose = require('mongoose');
+mongoose.plugin(schema => {
+  schema.options.usePushEach = true;
+});
 require('./song');
 require('./lyric');


### PR DESCRIPTION
As mentioned [here](https://github.com/Automattic/mongoose/issues/5924), mongodb dropped support of `$pushAll` since 3.6, which caused `Unknown modifier: $pushAll` for me and some other people.

Overriding mongoose settings to always use `usePushEach` solved the issue for me.