### PR TITLE
Fix bug: Deleting record by ID

### DIFF
--- a/server/schema/mutations.js
+++ b/server/schema/mutations.js
@@ -39,7 +39,7 @@ const mutation = new GraphQLObjectType({
       type: SongType,
       args: { id: { type: GraphQLID } },
       resolve(parentValue, { id }) {
-        return Song.findOneAndRemove(id);
+        return Song.findByIdAndRemove(id);
       }
     }
   }


### PR DESCRIPTION
This PR addresses the below issue:

Bug fix: Deleting a record by its ID
- A bug was identified in the record deletion functionality where records could not be properly deleted by their ID.
- I've implemented a fix to correctly delete records based on their ID, ensuring that the correct record is removed from the list.